### PR TITLE
Update dependency of Kiba to 1.0.0, < 2

### DIFF
--- a/kiba-plus.gemspec
+++ b/kiba-plus.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "kiba", "~> 0.6"
+  spec.add_runtime_dependency "kiba", "~> 1.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
The only code change from [0.6.x and 1.0.0](https://github.com/thbar/kiba/compare/v0.6.1...v1.0.0) is close the connection from all runners, should be ok.

Closes #8

